### PR TITLE
fix: standardize tags in AngouriMath.yml for consistency

### DIFF
--- a/_data/projects/AngouriMath.yml
+++ b/_data/projects/AngouriMath.yml
@@ -1,14 +1,13 @@
----
 name: AngouriMath
 desc: Computer algebra library for .NET
 site: https://am.angouri.org
 tags:
-- ".net"
-- math
-- computer-algebra
-- c#
-- f#
-- jupyter
+  - ".net"
+  - math
+  - computer-algebra
+  - c-sharp
+  - f-sharp
+  - jupyter
 upforgrabs:
   name: up-for-grabs
   link: https://github.com/asc-community/AngouriMath/labels/up-for-grabs


### PR DESCRIPTION
Replaced c# and f# tags with c-sharp and f-sharp for consistency with other project entries.
